### PR TITLE
feat: Create initial MIDI device component

### DIFF
--- a/device/README.md
+++ b/device/README.md
@@ -1,0 +1,76 @@
+# MIDI Device Emulator
+
+This component (`device/device.py`) emulates a simple MIDI device for testing purposes within the MIDI proxy system. It creates virtual MIDI input and output ports and responds to specific MIDI messages, particularly System Exclusive (SysEx) messages.
+
+## Features
+
+- Creates virtual MIDI input ("Python Test Device In") and output ("Python Test Device Out") ports.
+- Listens for incoming MIDI messages.
+- Handles standard MIDI messages (Note On/Off, Control Change) by logging them to the console.
+- Responds to specific SysEx messages.
+
+## Running the Device
+
+The device can be run as a standalone script for testing:
+
+```bash
+python device/device.py
+```
+
+Upon running, it will attempt to create its virtual MIDI ports and then wait for incoming MIDI messages. Press `Ctrl+C` to shut down the device.
+
+## Dependencies
+
+- `python-rtmidi`: For MIDI communication.
+- On Linux, ALSA utilities (`alsa-utils`) and development libraries (`libasound2-dev`) might be needed for `python-rtmidi` to function correctly, especially for virtual port creation.
+
+## SysEx Message Handling
+
+The device handles the following SysEx messages:
+
+### 1. Identity Request (Universal SysEx)
+
+-   **Received by Device:** `F0 7E 7F 06 01 F7`
+    -   `F0`: SysEx Start
+    -   `7E`: Universal Non-Realtime Message
+    -   `7F`: Target Device ID (All Call)
+    -   `06`: Sub-ID #1 (General Information)
+    -   `01`: Sub-ID #2 (Identity Request)
+    -   `F7`: SysEx End
+-   **Sent by Device (Identity Reply):** `F0 7E 7F 06 02 7D 01 01 01 01 01 01 01 01 F7`
+    -   `F0`: SysEx Start
+    -   `7E`: Universal Non-Realtime Message
+    -   `7F`: Device ID (Replying to All Call)
+    -   `06`: Sub-ID #1 (General Information)
+    -   `02`: Sub-ID #2 (Identity Reply)
+    -   `7D`: Manufacturer ID (Non-Commercial)
+    -   `01 01`: Device Family (LSB, MSB) - Placeholder
+    -   `01 01`: Device Model (LSB, MSB) - Placeholder
+    -   `01 01 01 01`: Version (LSB, MSB, Byte2, Byte3) - Placeholder (1.1.1.1)
+    -   `F7`: SysEx End
+
+### 2. Custom Trigger Action (Manufacturer Specific)
+
+This is a custom SysEx message defined for this device.
+
+-   **Manufacturer ID:** `0x7D` (Non-Commercial)
+-   **Device ID (for custom messages):** `0x01`
+
+-   **Message Format (Client -> Device):** `F0 7D <Device ID> <Command ID> <Action ID> F7`
+    -   `<Device ID>`: Must be `0x01`.
+    -   `<Command ID>`: Must be `0x03` (Trigger Action).
+    -   `<Action ID>`: Specifies the action. Currently, `0x01` is supported.
+
+-   **Example: Trigger Log Action (Action ID `0x01`)**
+    -   **Client -> Device:** `F0 7D 01 03 01 F7`
+    -   **Device Behavior:**
+        1.  Writes an entry to `device_actions.log` in the current working directory. The log entry includes the Action ID and the full SysEx message.
+            Example log line: `TriggerAction: ID=1, FullMsg=[240, 125, 1, 3, 1, 247]`
+        2.  Sends an acknowledgment (ACK) by echoing the received message back to the client: `F0 7D 01 03 01 F7`.
+
+## Observability
+
+-   **Console Logs:** The device prints information about its status (port opening, messages received/sent) to the console.
+-   **Action Log File (`device_actions.log`):** Specific actions, like the "Trigger Log Action" SysEx, are logged to this file. This file is cleared when the device starts.
+
+This README provides a basic overview for users and developers interacting with this test device.

--- a/device/device.py
+++ b/device/device.py
@@ -1,0 +1,207 @@
+import time
+import rtmidi # type: ignore
+import os # For file operations
+
+# SysEx constants
+SYSEX_START = 0xF0
+SYSEX_END = 0xF7
+UNIVERSAL_NON_REALTIME_SYSEX = 0x7E
+GENERAL_INFORMATION = 0x06
+IDENTITY_REQUEST = 0x01
+IDENTITY_REPLY = 0x02
+MANUFACTURER_ID = 0x7D  # Non-Commercial Manufacturer ID
+DEVICE_ID_SYSEX = 0x01 # Our device's ID for custom SysEx
+
+# Custom Command IDs
+COMMAND_TRIGGER_ACTION = 0x03
+
+# Action IDs for Trigger Action
+ACTION_ID_LOG = 0x01
+
+LOG_FILE_NAME = "device_actions.log"
+
+class Device:
+    def __init__(self, port_name='Python Test Device'):
+        self.port_name = port_name
+        self.midi_in = rtmidi.MidiIn()
+        self.midi_out = rtmidi.MidiOut()
+        self.shutdown_flag = False
+        self._setup_ports()
+        # Ensure log file is clear at start if it exists
+        if os.path.exists(LOG_FILE_NAME):
+            try:
+                os.remove(LOG_FILE_NAME)
+                print(f"Device: Cleared log file {LOG_FILE_NAME}")
+            except OSError as e:
+                print(f"Device: Error removing log file {LOG_FILE_NAME}: {e}")
+
+    def _setup_ports(self):
+        try:
+            self.midi_in.open_virtual_port(f"{self.port_name} In")
+            print(f"Device: Opened virtual input port: {self.port_name} In")
+        except rtmidi.RtMidiError as e:
+            print(f"Device: Error opening virtual input port: {e}")
+            available_ports_in = self.midi_in.get_ports()
+            if available_ports_in:
+                print(f"Device: Attempting to open available input port: {available_ports_in[0]}")
+                try:
+                    self.midi_in.open_port(0)
+                    print(f"Device: Successfully opened input port: {available_ports_in[0]}")
+                except rtmidi.RtMidiError as e_open:
+                    print(f"Device: Error opening available input port {available_ports_in[0]}: {e_open}")
+            else:
+                print("Device: No MIDI input ports available.")
+
+        try:
+            self.midi_out.open_virtual_port(f"{self.port_name} Out")
+            print(f"Device: Opened virtual output port: {self.port_name} Out")
+        except rtmidi.RtMidiError as e:
+            print(f"Device: Error opening virtual output port: {e}")
+            available_ports_out = self.midi_out.get_ports()
+            if available_ports_out:
+                print(f"Device: Attempting to open available output port: {available_ports_out[0]}")
+                try:
+                    self.midi_out.open_port(0)
+                    print(f"Device: Successfully opened output port: {available_ports_out[0]}")
+                except rtmidi.RtMidiError as e_open:
+                    print(f"Device: Error opening available output port {available_ports_out[0]}: {e_open}")
+            else:
+                print("Device: No MIDI output ports available.")
+
+        if self.midi_in.is_port_open():
+            self.midi_in.set_callback(self.on_midi_message)
+            print("Device: MIDI callback set.")
+        else:
+            print("Device: MIDI input port not open. Cannot set callback.")
+
+    def _handle_identity_request(self, message_bytes):
+        print("Device: Received Identity Request.")
+        # F0 7E 7F 06 02 7D <Device FamilyL> <Device FamilyM> <Device ModelL> <Device ModelM> <VersionL> <VersionM> <VersionByte2> <VersionByte3> F7
+        reply_message = [
+            SYSEX_START,
+            UNIVERSAL_NON_REALTIME_SYSEX,
+            0x7F, # Device ID (target for reply, 7F for 'all call' context)
+            GENERAL_INFORMATION,
+            IDENTITY_REPLY,
+            MANUFACTURER_ID,
+            0x01, 0x01,          # Device Family (LSB, MSB)
+            0x01, 0x01,          # Device Model (LSB, MSB)
+            0x01, 0x01, 0x01, 0x01, # Version (LSB, MSB, Byte2, Byte3)
+            SYSEX_END
+        ]
+        self.send_midi_message(reply_message)
+
+    def _handle_custom_sysex(self, message_bytes):
+        print(f"Device: Received Custom SysEx: {message_bytes}")
+        # Expected format: F0 7D <Device ID> <Command ID> <Payload...> F7
+        if len(message_bytes) < 5 or message_bytes[1] != MANUFACTURER_ID or message_bytes[2] != DEVICE_ID_SYSEX:
+            print("Device: Custom SysEx not for this device or malformed.")
+            return
+
+        command_id = message_bytes[3]
+
+        if command_id == COMMAND_TRIGGER_ACTION:
+            if len(message_bytes) >= 6: # F0 7D DevID CmdID ActionID F7
+                action_id = message_bytes[4]
+                self._handle_trigger_action(action_id, list(message_bytes)) # Pass as list
+            else:
+                print("Device: Trigger Action SysEx too short for Action ID.")
+        else:
+            print(f"Device: Unknown custom SysEx command ID: {command_id}")
+
+    def _handle_trigger_action(self, action_id, original_message):
+        print(f"Device: Handling Trigger Action, Action ID: {action_id}")
+        if action_id == ACTION_ID_LOG:
+            log_content = f"TriggerAction: ID={action_id}, FullMsg={original_message}\n"
+            try:
+                with open(LOG_FILE_NAME, "a") as f:
+                    f.write(log_content)
+                print(f"Device: Logged action to {LOG_FILE_NAME}")
+                # Acknowledge by echoing the command as per ARCHITECTURE.md
+                self.send_midi_message(original_message)
+            except IOError as e:
+                print(f"Device: Error writing to log file {LOG_FILE_NAME}: {e}")
+        else:
+            print(f"Device: Unknown Action ID for Trigger Action: {action_id}")
+
+    def on_midi_message(self, message_tuple, data):
+        message_bytes, deltatime = message_tuple
+        # print(f'Device: Raw Received MIDI: {message_bytes} (delta: {deltatime})')
+
+        if not message_bytes:
+            return
+
+        status_byte = message_bytes[0]
+
+        if status_byte == SYSEX_START and message_bytes[-1] == SYSEX_END:
+            # print("Device: SysEx message detected.")
+            # Universal Non-Realtime SysEx (e.g., Identity Request)
+            # F0 7E <device ID from message> 06 01 F7
+            if len(message_bytes) == 6 and \
+               message_bytes[0] == SYSEX_START and \
+               message_bytes[1] == UNIVERSAL_NON_REALTIME_SYSEX and \
+               message_bytes[3] == GENERAL_INFORMATION and \
+               message_bytes[4] == IDENTITY_REQUEST and \
+               message_bytes[5] == SYSEX_END:
+                self._handle_identity_request(list(message_bytes))
+            # Custom SysEx for our Manufacturer ID
+            # F0 7D <Device ID> <Command ID> <Payload...> F7
+            elif message_bytes[1] == MANUFACTURER_ID and message_bytes[2] == DEVICE_ID_SYSEX:
+                self._handle_custom_sysex(list(message_bytes))
+            else:
+                print(f"Device: Unrecognized or non-targeted SysEx: {message_bytes}")
+        elif status_byte >= 0x80 and status_byte <= 0xEF: # Channel Voice/Mode Messages
+            message_type = status_byte & 0xF0
+            channel = (status_byte & 0x0F) + 1
+            if message_type == 0x90: # Note On
+                 print(f"Device: Note On (Ch: {channel}, Note: {message_bytes[1]}, Vel: {message_bytes[2]})")
+            elif message_type == 0x80: # Note Off
+                 print(f"Device: Note Off (Ch: {channel}, Note: {message_bytes[1]}, Vel: {message_bytes[2]})")
+            elif message_type == 0xB0: # Control Change
+                 print(f"Device: Control Change (Ch: {channel}, CC: {message_bytes[1]}, Val: {message_bytes[2]})")
+            else:
+                print(f"Device: Other Channel Message (Type: {hex(message_type)}, Ch: {channel}): {message_bytes}")
+        elif status_byte >= 0xF0: # System Common Messages (excluding SysEx already handled)
+            print(f"Device: System Common Message: {message_bytes}")
+        else:
+            print(f"Device: Unknown or malformed message: {message_bytes}")
+
+    def send_midi_message(self, message):
+        if self.midi_out.is_port_open():
+            self.midi_out.send_message(message)
+            print(f'Device: Sent MIDI: {message}')
+        else:
+            print("Device: Output port not open. Cannot send message.")
+
+    def run(self):
+        print("Device: Starting main loop. Press Ctrl+C to exit.")
+        try:
+            while not self.shutdown_flag:
+                time.sleep(0.01)
+        except KeyboardInterrupt:
+            print("Device: KeyboardInterrupt received, shutting down.")
+        finally:
+            self.shutdown()
+
+    def shutdown(self):
+        print("Device: Shutting down...")
+        self.shutdown_flag = True
+        if hasattr(self, 'midi_in') and self.midi_in:
+            if self.midi_in.is_port_open():
+                 self.midi_in.close_port()
+                 print("Device: MIDI In port closed.")
+            del self.midi_in
+            print("Device: MIDI In object deleted.")
+
+        if hasattr(self, 'midi_out') and self.midi_out:
+            if self.midi_out.is_port_open():
+                self.midi_out.close_port()
+                print("Device: MIDI Out port closed.")
+            del self.midi_out
+            print("Device: MIDI Out object deleted.")
+
+        print("Device: Shutdown complete.")
+
+if __name__ == '__main__':
+    device = Device()
+    device.run()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,194 @@
+import unittest
+import time
+import rtmidi # type: ignore
+import os
+import threading # To run device in a separate thread
+
+# Assuming device.py is in the parent directory or PYTHONPATH is set up
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from device.device import Device, LOG_FILE_NAME, MANUFACTURER_ID, DEVICE_ID_SYSEX, COMMAND_TRIGGER_ACTION, ACTION_ID_LOG
+
+# SysEx constants for test messages
+SYSEX_START = 0xF0
+SYSEX_END = 0xF7
+UNIVERSAL_NON_REALTIME_SYSEX = 0x7E
+GENERAL_INFORMATION = 0x06
+IDENTITY_REQUEST_MSG = 0x01
+IDENTITY_REPLY_MSG = 0x02
+
+TEST_DEVICE_PORT_NAME = "TestMIDIDevice"
+CLIENT_PORT_NAME_OUT = "TestClientOut"
+CLIENT_PORT_NAME_IN = "TestClientIn"
+
+class TestDeviceSysExHandling(unittest.TestCase):
+
+    def setUp(self):
+        self.device_instance = None
+        self.device_thread = None
+        self.midi_out_to_device = rtmidi.MidiOut()
+        self.midi_in_from_device = rtmidi.MidiIn()
+        self.received_messages = []
+
+        # Open client output port to send to device's input
+        self.midi_out_to_device.open_virtual_port(CLIENT_PORT_NAME_OUT)
+        # Open client input port to receive from device's output
+        self.midi_in_from_device.open_virtual_port(CLIENT_PORT_NAME_IN)
+
+        # Callback for capturing messages from device
+        self.midi_in_from_device.set_callback(self._message_callback)
+
+        # Ensure log file is clean before test (Device also does this on init)
+        if os.path.exists(LOG_FILE_NAME):
+            os.remove(LOG_FILE_NAME)
+
+    def _message_callback(self, message, data):
+        msg_bytes, deltatime = message
+        print(f"TestClient: Received MIDI: {msg_bytes}")
+        self.received_messages.append(list(msg_bytes))
+
+    def _start_device(self):
+        self.device_instance = Device(port_name=TEST_DEVICE_PORT_NAME)
+        # Connect client output to device input
+        # Connect device output to client input
+        # This relies on rtmidi's port naming and discovery.
+        # We assume the virtual ports become available for connection.
+        # Note: rtmidi doesn't have explicit connect, it's about opening ports with known names
+        # or finding them and opening by index.
+
+        # For virtual ports, we send from CLIENT_PORT_NAME_OUT to TEST_DEVICE_PORT_NAME In
+        # and receive on CLIENT_PORT_NAME_IN from TEST_DEVICE_PORT_NAME Out.
+        # The Device class opens its ports as TEST_DEVICE_PORT_NAME In/Out.
+        # The test client opens CLIENT_PORT_NAME_OUT and CLIENT_PORT_NAME_IN.
+
+        # Find and open the device's input port for the client's output
+        time.sleep(0.2) # Give time for device ports to register
+        found_port = False
+        for i, port_name in enumerate(self.midi_out_to_device.get_ports()):
+            if TEST_DEVICE_PORT_NAME + " In" in port_name:
+                try:
+                    self.midi_out_to_device.close_port() # Close virtual if open
+                    self.midi_out_to_device.open_port(i, name=CLIENT_PORT_NAME_OUT) # name is for ALSA
+                    print(f"TestClient: Output connected to {port_name}")
+                    found_port = True
+                    break
+                except rtmidi.RtMidiError as e:
+                    print(f"TestClient: Failed to open output port {port_name} for sending: {e}")
+        if not found_port:
+             print(f"TestClient: Could not find device input port '{TEST_DEVICE_PORT_NAME} In' to connect client output. Available: {self.midi_out_to_device.get_ports()}")
+
+        # Find and open the device's output port for the client's input
+        found_port = False
+        for i, port_name in enumerate(self.midi_in_from_device.get_ports()):
+            if TEST_DEVICE_PORT_NAME + " Out" in port_name:
+                try:
+                    self.midi_in_from_device.close_port() # Close virtual if open
+                    self.midi_in_from_device.open_port(i, name=CLIENT_PORT_NAME_IN)
+                    self.midi_in_from_device.set_callback(self._message_callback) # re-set callback
+                    print(f"TestClient: Input connected to {port_name}")
+                    found_port = True
+                    break
+                except rtmidi.RtMidiError as e:
+                     print(f"TestClient: Failed to open input port {port_name} for receiving: {e}")
+        if not found_port:
+            print(f"TestClient: Could not find device output port '{TEST_DEVICE_PORT_NAME} Out' to connect client input. Available: {self.midi_in_from_device.get_ports()}")
+
+
+        self.device_thread = threading.Thread(target=self.device_instance.run, daemon=True)
+        self.device_thread.start()
+        time.sleep(0.5) # Allow device to fully initialize and open ports
+
+    def tearDown(self):
+        if self.device_instance:
+            self.device_instance.shutdown_flag = True # Signal shutdown
+            if self.device_thread:
+                 self.device_thread.join(timeout=2) # Wait for thread to finish
+
+        # Close client ports
+        if self.midi_out_to_device.is_port_open():
+            self.midi_out_to_device.close_port()
+        del self.midi_out_to_device
+
+        if self.midi_in_from_device.is_port_open():
+            self.midi_in_from_device.close_port()
+        del self.midi_in_from_device
+
+        # Clean up log file after tests if it was created
+        # if os.path.exists(LOG_FILE_NAME):
+        #     os.remove(LOG_FILE_NAME) # Device clears it on init, so maybe not needed here.
+        print("TestClient: Teardown complete.")
+
+    def test_identity_request(self):
+        print("\nTestClient: Running test_identity_request")
+        self._start_device()
+        if not self.midi_out_to_device.is_port_open() or not self.midi_in_from_device.is_port_open():
+            self.skipTest("MIDI ports for testing device not properly opened. Skipping test.")
+
+        identity_request_sysex = [
+            SYSEX_START,
+            UNIVERSAL_NON_REALTIME_SYSEX,
+            0x7F,  # Device ID (All Call)
+            GENERAL_INFORMATION,
+            IDENTITY_REQUEST_MSG,
+            SYSEX_END
+        ]
+
+        print(f"TestClient: Sending Identity Request: {identity_request_sysex}")
+        self.midi_out_to_device.send_message(identity_request_sysex)
+        time.sleep(0.5)  # Give device time to respond
+
+        self.assertTrue(len(self.received_messages) > 0, "Device did not send any message in response.")
+
+        expected_reply = [
+            SYSEX_START,
+            UNIVERSAL_NON_REALTIME_SYSEX,
+            0x7F, # Device ID for reply to all-call
+            GENERAL_INFORMATION,
+            IDENTITY_REPLY_MSG,
+            MANUFACTURER_ID,     # 0x7D
+            0x01, 0x01,          # Device Family LSB, MSB
+            0x01, 0x01,          # Device Model LSB, MSB
+            0x01, 0x01, 0x01, 0x01, # Version LSB, MSB, B2, B3
+            SYSEX_END
+        ]
+        self.assertIn(expected_reply, self.received_messages,
+                        f"Device did not send correct Identity Reply. Expected: {expected_reply}, Got: {self.received_messages}")
+        print("TestClient: test_identity_request PASSED")
+
+    def test_trigger_action_log_and_ack(self):
+        print("\nTestClient: Running test_trigger_action_log_and_ack")
+        self._start_device()
+        if not self.midi_out_to_device.is_port_open() or not self.midi_in_from_device.is_port_open():
+            self.skipTest("MIDI ports for testing device not properly opened. Skipping test.")
+
+        action_id_to_log = ACTION_ID_LOG # 0x01
+        trigger_action_sysex = [
+            SYSEX_START,
+            MANUFACTURER_ID,    # 0x7D
+            DEVICE_ID_SYSEX,    # 0x01 (Our virtual device's ID)
+            COMMAND_TRIGGER_ACTION, # 0x03
+            action_id_to_log,   # Action ID
+            SYSEX_END
+        ]
+
+        print(f"TestClient: Sending Trigger Action: {trigger_action_sysex}")
+        self.midi_out_to_device.send_message(trigger_action_sysex)
+        time.sleep(0.5)  # Give device time to process, log, and ACK
+
+        # 1. Check for ACK (echoed message)
+        self.assertTrue(len(self.received_messages) > 0, "Device did not send any message (ACK) in response.")
+        self.assertIn(trigger_action_sysex, self.received_messages,
+                        f"Device did not ACK TriggerAction correctly. Expected: {trigger_action_sysex}, Got: {self.received_messages}")
+
+        # 2. Check log file content
+        self.assertTrue(os.path.exists(LOG_FILE_NAME), f"Log file '{LOG_FILE_NAME}' was not created.")
+        with open(LOG_FILE_NAME, 'r') as f:
+            log_content = f.read()
+
+        expected_log_entry_part = f"TriggerAction: ID={action_id_to_log}, FullMsg={trigger_action_sysex}"
+        self.assertIn(expected_log_entry_part, log_content,
+                        f"Log file does not contain expected entry. Expected part: '{expected_log_entry_part}', Got: '{log_content}'")
+        print("TestClient: test_trigger_action_log_and_ack PASSED")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces the initial implementation of the MIDI Device component.

The `Device` class, located in `device/device.py`, emulates a MIDI device for testing purposes. It creates virtual MIDI input and output ports named "Python Test Device In" and "Python Test Device Out".

Key features implemented:
- Virtual MIDI port creation using `python-rtmidi`.
- Handling of Universal SysEx Identity Request:
    - Receives: `F0 7E 7F 06 01 F7`
    - Responds: `F0 7E 7F 06 02 7D 01 01 01 01 01 01 01 01 F7`
- Handling of a custom SysEx "Trigger Action" message:
    - Manufacturer ID: `0x7D`
    - Device ID: `0x01`
    - Command ID: `0x03`
    - Example (Action ID `0x01` for logging): `F0 7D 01 03 01 F7`
    - Upon receiving this, the device logs the action and the full message to `device_actions.log` (e.g., "TriggerAction: ID=1, FullMsg=[240, 125, 1, 3, 1, 247]") and sends an ACK by echoing the original message.
- Placeholder logging for standard MIDI messages (Note On/Off, CC) to the console.
- The `device_actions.log` file is cleared upon device initialization.

Unit tests (`tests/test_device.py`) have been added to verify the SysEx handling functionalities. These tests cover the Identity Request/Reply and the Trigger Action's logging and acknowledgment behavior. Due to limitations in the CI environment (missing ALSA `snd-seq` kernel module), these tests could not be executed successfully during this development cycle but are structurally complete.

A `device/README.md` file has been added to document the device's functionality, how to run it, and the SysEx messages it supports.