### PR TITLE
feat: Add MIDI client component and tests

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -1,0 +1,232 @@
+import time
+import rtmidi # type: ignore
+
+# SysEx constants from ARCHITECTURE.md
+SYSEX_START = 0xF0
+SYSEX_END = 0xF7
+UNIVERSAL_NON_REALTIME_SYSEX = 0x7E
+GENERAL_INFORMATION = 0x06
+IDENTITY_REQUEST_MSG_ID = 0x01 # ID for Identity Request message
+# MANUFACTURER_ID will be used for custom messages
+MANUFACTURER_ID = 0x7D # Non-Commercial
+DEVICE_ID_CLIENT_TARGETS = 0x01 # Assuming client targets device with ID 0x01
+
+# Custom Command IDs from ARCHITECTURE.md
+COMMAND_SET_PARAMETER = 0x01
+COMMAND_GET_PARAMETER = 0x02
+COMMAND_TRIGGER_ACTION = 0x03
+
+class Client:
+    def __init__(self, client_port_name='Python Test Client'):
+        self.client_port_name = client_port_name
+        self.midi_in = rtmidi.MidiIn()
+        self.midi_out = rtmidi.MidiOut()
+
+        self.target_device_in_port_name = None
+        self.target_device_out_port_name = None
+
+        self._received_messages = []
+        self._message_callback_event = None # For synchronization if needed
+
+        self._open_client_ports()
+
+    def _open_client_ports(self):
+        try:
+            self.midi_in.open_virtual_port(f"{self.client_port_name} In")
+            print(f"Client: Opened virtual input port: {self.client_port_name} In")
+        except rtmidi.RtMidiError as e:
+            print(f"Client: Error opening virtual input port: {e}")
+            # Fallback or error handling if needed
+
+        try:
+            self.midi_out.open_virtual_port(f"{self.client_port_name} Out")
+            print(f"Client: Opened virtual output port: {self.client_port_name} Out")
+        except rtmidi.RtMidiError as e:
+            print(f"Client: Error opening virtual output port: {e}")
+            # Fallback or error handling if needed
+
+        if self.midi_in.is_port_open():
+            self.midi_in.set_callback(self._on_midi_message)
+            print("Client: MIDI callback set on input port.")
+        else:
+            print("Client: Client MIDI input port not open. Cannot set callback.")
+
+    def _on_midi_message(self, message_tuple, data):
+        message_bytes, deltatime = message_tuple
+        print(f'Client: Raw Received MIDI: {message_bytes} (delta: {deltatime})')
+        self._received_messages.append(list(message_bytes))
+        # If using an event to signal message arrival:
+        # if self._message_callback_event:
+        #     self._message_callback_event.set()
+
+    def connect_to_device(self, device_in_port_name_substr, device_out_port_name_substr):
+        self.target_device_in_port_name = device_in_port_name_substr
+        self.target_device_out_port_name = device_out_port_name_substr
+
+        # Connect client's output to device's input port
+        connected_out = False
+        available_ports = self.midi_out.get_ports()
+        # print(f"Client: Available MIDI output ports for connection: {available_ports}")
+        for i, port_name in enumerate(available_ports):
+            if self.target_device_in_port_name in port_name:
+                try:
+                    self.midi_out.close_port() # Close virtual port first
+                    self.midi_out.open_port(i)
+                    print(f"Client: Output connected to device input port: {port_name}")
+                    connected_out = True
+                    break
+                except rtmidi.RtMidiError as e:
+                    print(f"Client: Error connecting output to {port_name}: {e}")
+        if not connected_out:
+            print(f"Client: Could not find or connect to device input port containing '{self.target_device_in_port_name}'. Available: {available_ports}")
+            return False
+
+        # Connect client's input to device's output port
+        connected_in = False
+        available_ports_in = self.midi_in.get_ports()
+        # print(f"Client: Available MIDI input ports for connection: {available_ports_in}")
+        for i, port_name in enumerate(available_ports_in):
+            if self.target_device_out_port_name in port_name:
+                try:
+                    self.midi_in.close_port() # Close virtual port first
+                    self.midi_in.open_port(i)
+                    self.midi_in.set_callback(self._on_midi_message) # Re-set callback
+                    print(f"Client: Input connected to device output port: {port_name}")
+                    connected_in = True
+                    break
+                except rtmidi.RtMidiError as e:
+                    print(f"Client: Error connecting input to {port_name}: {e}")
+        if not connected_in:
+            print(f"Client: Could not find or connect to device output port containing '{self.target_device_out_port_name}'. Available: {available_ports_in}")
+            # Attempt to re-open virtual port if connection failed
+            self._open_client_ports() # This might re-open the virtual port if it was closed
+            return False
+
+        return connected_out and connected_in
+
+    def send_midi_message(self, message_list):
+        if self.midi_out.is_port_open():
+            self.midi_out.send_message(message_list)
+            print(f'Client: Sent MIDI: {message_list}')
+        else:
+            print("Client: Output port not open or not connected. Cannot send message.")
+
+    def pop_received_message(self, timeout_sec=0.1):
+        start_time = time.time()
+        while (time.time() - start_time) < timeout_sec:
+            if self._received_messages:
+                return self._received_messages.pop(0)
+            time.sleep(0.01) # short sleep to avoid busy waiting
+        return None
+
+    def clear_received_messages(self):
+        self._received_messages = []
+
+    # --- SysEx Sending Methods ---
+    def send_identity_request(self):
+        # Message: F0 7E 7F 06 01 F7 (Universal System Exclusive - Identity Request)
+        # 7F as device ID in request means "all devices"
+        message = [
+            SYSEX_START,
+            UNIVERSAL_NON_REALTIME_SYSEX,
+            0x7F, # Target Device ID (7F for "all call")
+            GENERAL_INFORMATION,
+            IDENTITY_REQUEST_MSG_ID,
+            SYSEX_END
+        ]
+        self.send_midi_message(message)
+
+    def send_set_parameter(self, parameter_id, parameter_value):
+        # Message Format: F0 7D <Device ID> <Command ID> <Parameter ID> <Parameter Value> F7
+        message = [
+            SYSEX_START,
+            MANUFACTURER_ID,
+            DEVICE_ID_CLIENT_TARGETS,
+            COMMAND_SET_PARAMETER,
+            parameter_id,
+            parameter_value,
+            SYSEX_END
+        ]
+        self.send_midi_message(message)
+
+    def send_get_parameter(self, parameter_id):
+        # Message Format: F0 7D <Device ID> <Command ID> <Parameter ID> F7
+        message = [
+            SYSEX_START,
+            MANUFACTURER_ID,
+            DEVICE_ID_CLIENT_TARGETS,
+            COMMAND_GET_PARAMETER,
+            parameter_id,
+            SYSEX_END
+        ]
+        self.send_midi_message(message)
+
+    def send_trigger_action(self, action_id):
+        # Message Format: F0 7D <Device ID> <Command ID> <Action ID> F7
+        message = [
+            SYSEX_START,
+            MANUFACTURER_ID,
+            DEVICE_ID_CLIENT_TARGETS,
+            COMMAND_TRIGGER_ACTION,
+            action_id,
+            SYSEX_END
+        ]
+        self.send_midi_message(message)
+
+    def shutdown(self):
+        print("Client: Shutting down...")
+        if hasattr(self, 'midi_in') and self.midi_in:
+            if self.midi_in.is_port_open():
+                self.midi_in.close_port()
+                print("Client: MIDI In port closed.")
+            del self.midi_in
+
+        if hasattr(self, 'midi_out') and self.midi_out:
+            if self.midi_out.is_port_open():
+                self.midi_out.close_port()
+                print("Client: MIDI Out port closed.")
+            del self.midi_out
+        print("Client: Shutdown complete.")
+
+if __name__ == '__main__':
+    # Example Usage (Optional - for basic manual testing)
+    print("Client: Basic test script started.")
+    client = Client()
+
+    # In a real scenario, you'd need a device running.
+    # For this example, we'll just try to send.
+    # These port names would correspond to a running Device instance's ports.
+    DEVICE_IN_PORT_SUBSTR = "Test Device In" # Or whatever the device calls its input
+    DEVICE_OUT_PORT_SUBSTR = "Test Device Out" # Or whatever the device calls its output
+
+    print(f"Client: Attempting to connect to device ports containing '{DEVICE_IN_PORT_SUBSTR}' (for client out) and '{DEVICE_OUT_PORT_SUBSTR}' (for client in)")
+
+    # Give a moment for ports to be potentially available if a device was just started
+    time.sleep(1)
+
+    if client.connect_to_device(DEVICE_IN_PORT_SUBSTR, DEVICE_OUT_PORT_SUBSTR):
+        print("Client: Successfully connected to device ports.")
+        client.send_identity_request()
+
+        # Wait for a response (if any)
+        response = client.pop_received_message(timeout_sec=1.0)
+        if response:
+            print(f"Client: Received response: {response}")
+        else:
+            print("Client: No response received for Identity Request within timeout.")
+
+        # Example: Send a trigger action
+        ACTION_ID_TEST = 0x01 # Example Action ID
+        print(f"Client: Sending Trigger Action with Action ID {ACTION_ID_TEST}")
+        client.send_trigger_action(ACTION_ID_TEST)
+        response_action = client.pop_received_message(timeout_sec=1.0)
+        if response_action:
+            print(f"Client: Received response for action: {response_action}")
+        else:
+            print("Client: No response received for Trigger Action within timeout.")
+
+    else:
+        print("Client: Failed to connect to device ports. Please ensure a compatible MIDI device is running and its ports are discoverable.")
+
+    client.shutdown()
+    print("Client: Basic test script finished.")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,220 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+import time # For potential timing related tests if any
+
+# Add client directory to sys.path to allow direct import
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from client.client import Client, SYSEX_START, SYSEX_END, MANUFACTURER_ID, DEVICE_ID_CLIENT_TARGETS,                           UNIVERSAL_NON_REALTIME_SYSEX, GENERAL_INFORMATION, IDENTITY_REQUEST_MSG_ID,                           COMMAND_SET_PARAMETER, COMMAND_GET_PARAMETER, COMMAND_TRIGGER_ACTION
+
+# Define a name for the mock client ports that won't conflict with real ports
+MOCK_CLIENT_PORT_NAME = "MockTestClient"
+
+class TestClientUnit(unittest.TestCase):
+
+    @patch('client.client.rtmidi.MidiIn')
+    @patch('client.client.rtmidi.MidiOut')
+    def setUp(self, MockMidiOut, MockMidiIn):
+        # Instantiate mocks for MidiIn and MidiOut
+        self.mock_midi_in_instance = MockMidiIn.return_value
+        self.mock_midi_out_instance = MockMidiOut.return_value
+
+        # Configure mocks to simulate successful port opening
+        self.mock_midi_in_instance.is_port_open.return_value = True
+        self.mock_midi_out_instance.is_port_open.return_value = True
+        self.mock_midi_in_instance.get_ports.return_value = [] # Default for connect_to_device
+        self.mock_midi_out_instance.get_ports.return_value = [] # Default for connect_to_device
+
+        # Store the callback
+        self.callback_info = {'function': None, 'data': None}
+
+        def mock_set_callback(func, data=None):
+            self.callback_info['function'] = func
+            self.callback_info['data'] = data
+
+        self.mock_midi_in_instance.set_callback = mock_set_callback
+
+        # Create Client instance. This will call _open_client_ports
+        self.client = Client(client_port_name=MOCK_CLIENT_PORT_NAME)
+
+        # Clear any messages that might have been logged during init by print statements
+        self.client.clear_received_messages()
+
+
+    def tearDown(self):
+        self.client.shutdown()
+        # Reset mocks if necessary, though typically new mocks are created per test method by @patch
+        pass
+
+    def test_client_opens_virtual_ports_on_init(self):
+        # Check if open_virtual_port was called on the mock instances
+        self.mock_midi_in_instance.open_virtual_port.assert_called_with(f"{MOCK_CLIENT_PORT_NAME} In")
+        self.mock_midi_out_instance.open_virtual_port.assert_called_with(f"{MOCK_CLIENT_PORT_NAME} Out")
+        self.assertIsNotNone(self.callback_info['function'], "Callback should be set on MIDI input.")
+
+    def test_send_midi_message(self):
+        test_message = [0x90, 0x3C, 0x7F] # Note On
+        self.client.send_midi_message(test_message)
+        self.mock_midi_out_instance.send_message.assert_called_once_with(test_message)
+
+    def test_receive_midi_message_callback(self):
+        # Simulate a message arrival via the callback
+        test_midi_message = ([0xB0, 0x07, 0x7F], 0.0) # Control Change, delta time
+
+        # Ensure callback is set up
+        self.assertIsNotNone(self.callback_info['function'])
+
+        # Call the callback directly
+        self.callback_info['function'](test_midi_message, self.callback_info['data'])
+
+        received = self.client.pop_received_message(timeout_sec=0.01) # Should be instant
+        self.assertEqual(received, test_midi_message[0])
+
+    def test_pop_received_message_timeout(self):
+        message = self.client.pop_received_message(timeout_sec=0.01)
+        self.assertIsNone(message, "Should return None if no message received within timeout")
+
+    def test_clear_received_messages(self):
+        # Simulate a message arrival
+        test_midi_message = ([0x90, 0x40, 0x70], 0.0)
+        self.callback_info['function'](test_midi_message, self.callback_info['data'])
+
+        # Verify it's there
+        self.assertIsNotNone(self.client.pop_received_message(timeout_sec=0.01))
+
+        # Simulate another message and clear
+        self.callback_info['function'](test_midi_message, self.callback_info['data'])
+        self.client.clear_received_messages()
+        self.assertIsNone(self.client.pop_received_message(timeout_sec=0.01), "Messages should be cleared")
+
+    # --- Test SysEx Message Formatting ---
+    def test_send_identity_request(self):
+        self.client.send_identity_request()
+        expected_message = [
+            SYSEX_START, UNIVERSAL_NON_REALTIME_SYSEX, 0x7F,
+            GENERAL_INFORMATION, IDENTITY_REQUEST_MSG_ID, SYSEX_END
+        ]
+        self.mock_midi_out_instance.send_message.assert_called_once_with(expected_message)
+
+    def test_send_set_parameter(self):
+        param_id, param_val = 0x10, 0x5A
+        self.client.send_set_parameter(param_id, param_val)
+        expected_message = [
+            SYSEX_START, MANUFACTURER_ID, DEVICE_ID_CLIENT_TARGETS,
+            COMMAND_SET_PARAMETER, param_id, param_val, SYSEX_END
+        ]
+        self.mock_midi_out_instance.send_message.assert_called_once_with(expected_message)
+
+    def test_send_get_parameter(self):
+        param_id = 0x12
+        self.client.send_get_parameter(param_id)
+        expected_message = [
+            SYSEX_START, MANUFACTURER_ID, DEVICE_ID_CLIENT_TARGETS,
+            COMMAND_GET_PARAMETER, param_id, SYSEX_END
+        ]
+        self.mock_midi_out_instance.send_message.assert_called_once_with(expected_message)
+
+    def test_send_trigger_action(self):
+        action_id = 0x05
+        self.client.send_trigger_action(action_id)
+        expected_message = [
+            SYSEX_START, MANUFACTURER_ID, DEVICE_ID_CLIENT_TARGETS,
+            COMMAND_TRIGGER_ACTION, action_id, SYSEX_END
+        ]
+        self.mock_midi_out_instance.send_message.assert_called_once_with(expected_message)
+
+    @patch('client.client.rtmidi.MidiOut') # Need fresh MidiOut for this test
+    @patch('client.client.rtmidi.MidiIn')
+    def test_connect_to_device_success(self, MockMidiInAgain, MockMidiOutAgain):
+        # Setup fresh mocks for this specific test to control get_ports
+        mock_in = MockMidiInAgain.return_value
+        mock_out = MockMidiOutAgain.return_value
+
+        mock_in.is_port_open.return_value = True # Simulates virtual port being open initially
+        mock_out.is_port_open.return_value = True
+
+        device_in_port_name = "MockDevice MIDI In"
+        device_out_port_name = "MockDevice MIDI Out"
+
+        # Simulate get_ports returning the target device ports
+        mock_out.get_ports.return_value = ["Other Port", device_in_port_name, "Another Port"]
+        mock_in.get_ports.return_value = [device_out_port_name, "Some Other Input"]
+
+        # Create a new client instance for this test to use the new mocks for port opening
+        client_for_connect_test = Client(client_port_name="ConnectClient")
+
+        # Override the default mock instances with the ones for this test
+        client_for_connect_test.midi_in = mock_in
+        client_for_connect_test.midi_out = mock_out
+
+        # Mock the set_callback method on the fresh mock_in
+        mock_in.set_callback = MagicMock()
+
+
+        result = client_for_connect_test.connect_to_device(
+            device_in_port_name_substr="MockDevice MIDI In",
+            device_out_port_name_substr="MockDevice MIDI Out"
+        )
+        self.assertTrue(result, "Connection should be successful")
+
+        # Check that close_port was called (to close virtual) and open_port was called (to connect to specific)
+        mock_out.close_port.assert_called_once()
+        mock_out.open_port.assert_called_once_with(1) # Index of "MockDevice MIDI In"
+
+        mock_in.close_port.assert_called_once()
+        mock_in.open_port.assert_called_once_with(0) # Index of "MockDevice MIDI Out"
+        mock_in.set_callback.assert_called() # Callback should be re-set
+
+        client_for_connect_test.shutdown()
+
+
+    @patch('client.client.rtmidi.MidiOut')
+    @patch('client.client.rtmidi.MidiIn')
+    def test_connect_to_device_fail_input_not_found(self, MockMidiInAgain, MockMidiOutAgain):
+        mock_in = MockMidiInAgain.return_value
+        mock_out = MockMidiOutAgain.return_value
+        mock_in.is_port_open.return_value = True
+        mock_out.is_port_open.return_value = True
+
+        device_in_port_name = "MockDevice MIDI In"
+
+        mock_out.get_ports.return_value = [device_in_port_name]
+        mock_in.get_ports.return_value = ["Some Other Input"] # Target device output not present
+
+        client_for_connect_test = Client(client_port_name="ConnectFailClient")
+        client_for_connect_test.midi_in = mock_in
+        client_for_connect_test.midi_out = mock_out
+
+        # Need to mock open_virtual_port on these instances as it's called in _open_client_ports
+        mock_in.open_virtual_port = MagicMock()
+        mock_out.open_virtual_port = MagicMock()
+        def mock_set_callback_local(func, data=None): pass
+        mock_in.set_callback = mock_set_callback_local
+
+
+        result = client_for_connect_test.connect_to_device(
+            device_in_port_name_substr="MockDevice MIDI In",
+            device_out_port_name_substr="NonExistentDeviceOutput"
+        )
+        self.assertFalse(result, "Connection should fail if device output port not found")
+
+        # Check that it attempts to re-open client's own virtual input port
+        mock_in.open_virtual_port.assert_called_with(f"ConnectFailClient In")
+
+        client_for_connect_test.shutdown()
+
+    def test_shutdown_closes_ports(self):
+        # This test relies on the mocks set up in setUp
+        self.client.shutdown()
+        self.mock_midi_in_instance.close_port.assert_called_once()
+        self.mock_midi_out_instance.close_port.assert_called_once()
+        # Check if 'del' was called - this is harder to check directly for instance variables.
+        # We rely on the print statements in the actual shutdown for now, or by checking
+        # if the objects are truly gone if we had access, but for unit tests,
+        # checking close_port is the primary interaction.
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces the initial version of the MIDI client component (`client/client.py`).

The client is capable of:
- Opening virtual MIDI input and output ports using `rtmidi`.
- Connecting to specified device MIDI ports.
- Sending predefined System Exclusive (SysEx) messages:
    - Identity Request
    - Set Parameter
    - Get Parameter
    - Trigger Action
- Receiving MIDI messages via a callback mechanism.

Unit tests (`tests/test_client.py`) are included for the client, mocking the `rtmidi` library to ensure the client's logic for message formatting, port handling, and message processing is correct. I've confirmed these tests are passing.

Integration tests (`tests/test_integration_client_device.py`) have also been created to test the interaction between the new client and the existing device component. However, I couldn't successfully run these tests in the current development environment due to a lack of ALSA MIDI support, which `rtmidi` relies upon. The test code is available for environments that do support ALSA.

The `device/device.py` was slightly updated to make its shutdown procedure more robust based on findings during client unit test development.